### PR TITLE
Fix timezone issue 

### DIFF
--- a/src/components/date-time.js
+++ b/src/components/date-time.js
@@ -1,0 +1,25 @@
+import { StatNumber, Tooltip, Box } from "@chakra-ui/core";
+import React from "react";
+import { getGMTOffset } from "../utils/date-calc";
+import {
+  formatDateTime,
+  formatDateTimeToTargetLocale,
+} from "../utils/format-date";
+
+export default function DateTime({ timestamp }) {
+  const timeZoneOffset = getGMTOffset(timestamp);
+  const targetLocaleDateTime = formatDateTimeToTargetLocale(
+    timestamp,
+    timeZoneOffset
+  );
+  const currentLocalDateTime = formatDateTime(timestamp);
+  return (
+    <StatNumber>
+      <Tooltip label={currentLocalDateTime} placement="right">
+        <Box as="span">
+          {targetLocaleDateTime} GMT{timeZoneOffset}
+        </Box>
+      </Tooltip>
+    </StatNumber>
+  );
+}

--- a/src/components/launch.js
+++ b/src/components/launch.js
@@ -22,9 +22,9 @@ import {
 } from "@chakra-ui/core";
 
 import { useSpaceX } from "../utils/use-space-x";
-import { formatDateTime } from "../utils/format-date";
 import Error from "./error";
 import Breadcrumbs from "./breadcrumbs";
+import DateTime from "./date-time";
 
 export default function Launch() {
   let { launchId } = useParams();
@@ -123,10 +123,8 @@ function TimeAndLocation({ launch }) {
             Launch Date
           </Box>
         </StatLabel>
-        <StatNumber fontSize={["md", "xl"]}>
-          {formatDateTime(launch.launch_date_local)}
-        </StatNumber>
-        <StatHelpText>{timeAgo(launch.launch_date_utc)}</StatHelpText>
+        <DateTime timestamp={launch.launch_date_local} />
+        <StatHelpText>{timeAgo(launch.launch_date_local)}</StatHelpText>
       </Stat>
       <Stat>
         <StatLabel display="flex">

--- a/src/components/launches.js
+++ b/src/components/launches.js
@@ -4,7 +4,7 @@ import { format as timeAgo } from "timeago.js";
 import { Link } from "react-router-dom";
 
 import { useSpaceXPaginated } from "../utils/use-space-x";
-import { formatDate } from "../utils/format-date";
+import { formatDateToTargetLocale } from "../utils/format-date";
 import Error from "./error";
 import Breadcrumbs from "./breadcrumbs";
 import LoadMoreButton from "./load-more-button";
@@ -17,7 +17,7 @@ export default function Launches() {
     {
       limit: PAGE_SIZE,
       order: "desc",
-      sort: "launch_date_utc",
+      sort: "launch_date_local",
     }
   );
   console.log(data, error);
@@ -111,9 +111,11 @@ export function LaunchItem({ launch }) {
           {launch.mission_name}
         </Box>
         <Flex>
-          <Text fontSize="sm">{formatDate(launch.launch_date_utc)} </Text>
+          <Text fontSize="sm">
+            {formatDateToTargetLocale(launch.launch_date_local)}{" "}
+          </Text>
           <Text color="gray.500" ml="2" fontSize="sm">
-            {timeAgo(launch.launch_date_utc)}
+            {timeAgo(launch.launch_date_local)}
           </Text>
         </Flex>
       </Box>

--- a/src/utils/date-calc.js
+++ b/src/utils/date-calc.js
@@ -1,0 +1,21 @@
+const MIN_TO_MS = 60000;
+const HOURS_TO_MS = MIN_TO_MS * 60;
+
+export function getGMTOffset(timestamp) {
+  const offsetFromString = timestamp.substr(19, 6);
+  const hours = parseInt(offsetFromString.substr(1, 2));
+  const minutes = parseInt(offsetFromString.substr(4, 2));
+  const isBehind = offsetFromString[0] !== "-";
+  const offset = hours + minutes / 60;
+  return offset * (isBehind || -1);
+}
+
+export function getFormattedTimeZoneDate(timestamp, offset) {
+  const date = new Date(timestamp);
+  const timezoneOffsetInMilliseconds = date.getTimezoneOffset() * MIN_TO_MS;
+  const utcTime = date.getTime() + timezoneOffsetInMilliseconds;
+  if (offset === "") {
+    return new Date(utcTime + getGMTOffset(timestamp) * HOURS_TO_MS);
+  }
+  return new Date(utcTime + offset * 3600000);
+}

--- a/src/utils/format-date.js
+++ b/src/utils/format-date.js
@@ -1,20 +1,42 @@
+import { getFormattedTimeZoneDate } from "./date-calc";
+
+const DATE_FORMAT_CONFIG = Object.freeze({
+  weekday: "long",
+  year: "numeric",
+  month: "long",
+  day: "numeric",
+});
+
+const DATE_TIME_FORMAT_CONFIG = Object.freeze({
+  year: "numeric",
+  month: "long",
+  day: "numeric",
+  hour: "numeric",
+  minute: "numeric",
+  second: "numeric",
+});
+
 export function formatDate(timestamp) {
-  return new Intl.DateTimeFormat("en-US", {
-    weekday: "long",
-    year: "numeric",
-    month: "long",
-    day: "numeric",
-  }).format(new Date(timestamp));
+  return new Intl.DateTimeFormat("en-US", DATE_FORMAT_CONFIG).format(
+    new Date(timestamp)
+  );
 }
 
 export function formatDateTime(timestamp) {
   return new Intl.DateTimeFormat("en-US", {
-    year: "numeric",
-    month: "long",
-    day: "numeric",
-    hour: "numeric",
-    minute: "numeric",
-    second: "numeric",
+    ...DATE_TIME_FORMAT_CONFIG,
     timeZoneName: "short",
   }).format(new Date(timestamp));
+}
+
+export function formatDateToTargetLocale(timestamp, offset = "") {
+  return new Intl.DateTimeFormat("en-US", DATE_FORMAT_CONFIG).format(
+    getFormattedTimeZoneDate(timestamp, offset)
+  );
+}
+
+export function formatDateTimeToTargetLocale(timestamp, offset = "") {
+  return new Intl.DateTimeFormat("en-US", DATE_TIME_FORMAT_CONFIG).format(
+    getFormattedTimeZoneDate(timestamp, offset)
+  );
 }


### PR DESCRIPTION
The fixes the timezone issue where the locale was not the actual site's locale and it changes based on the clients timezone.

### Implementation approach
- Creates a DateTime component that can be reused in all pages
- Creates a util which takes the date timestamp and does the following
  - Parses timezone information
  - Identifies the timezone and the get's the locale time based on the offset that is provided
- It also implements the relevant date utils in `format-date.js` 
- Changes the sorting order to be based on the locale time 

### Date API's
- The parsing API expects the a format like `2020-10-24T11:31:00-04:00`. The implementation extracts the timezone offset and then uses that to identify the local time from the UTC string. 



### Possible improvements
- We can add a better debug messages if an unidentified format is parsed by the offset function

### Usage
To start application
`yarn start`

